### PR TITLE
fix(dialogs): replace QFileDialog with PowerShell WinForms on Windows 11

### DIFF
--- a/src/DBCUtility.py
+++ b/src/DBCUtility.py
@@ -38,7 +38,7 @@ import os
 import re
 from pathlib import Path
 
-from resource_utils import get_resource_path
+from resource_utils import get_resource_path, open_file_dialog
 
 def _clean_comment_text(comment_text: object) -> str:
     """
@@ -367,9 +367,7 @@ class ConverterWindow(QtWidgets.QWidget):
 
     def select_dbc_file(self):
         try:
-            file_name, _ = QtWidgets.QFileDialog.getOpenFileName(
-                self, "Select DBC File", "", "DBC Files (*.dbc);;All Files (*)"
-            )
+            file_name = open_file_dialog("Select DBC File", "DBC Files (*.dbc);;All Files (*)")
             if file_name:
                 self._prepare_new_dbc(file_name)
         except Exception as e:

--- a/src/dbc_editor_ui.py
+++ b/src/dbc_editor_ui.py
@@ -14,7 +14,7 @@ import json
 from dbc_editor import DBCEditor, DBCEditorError
 from search_module import UnifiedSearchWidget
 
-from resource_utils import get_resource_path
+from resource_utils import get_resource_path, open_file_dialog, save_file_dialog
 
 class MessageEditDialog(QtWidgets.QDialog):
     """Enhanced dialog for editing message properties."""
@@ -796,9 +796,7 @@ class DBCEditorWidget(QtWidgets.QWidget):
                 return
         
         try:
-            file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
-                self, "Load DBC File", "", "DBC Files (*.dbc);;All Files (*)"
-            )
+            file_path = open_file_dialog("Load DBC File", "DBC Files (*.dbc);;All Files (*)")
             if file_path:
                 self.load_dbc_path(file_path)
         except Exception as e:
@@ -1218,9 +1216,7 @@ class DBCEditorWidget(QtWidgets.QWidget):
     def save_as(self):
         """Save changes to a new file with error handling."""
         try:
-            file_path, _ = QtWidgets.QFileDialog.getSaveFileName(
-                self, "Save DBC File As", "", "DBC Files (*.dbc);;All Files (*)"
-            )
+            file_path = save_file_dialog("Save DBC File As", "DBC Files (*.dbc);;All Files (*)")
             if file_path:
                 # Ensure .dbc extension
                 if not file_path.lower().endswith('.dbc'):

--- a/src/home_screen.py
+++ b/src/home_screen.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 from about_dialog import AboutDialog
-from resource_utils import get_resource_path
+from resource_utils import get_resource_path, open_file_dialog
 
 class RecentFilesManager(QtCore.QObject):
     """
@@ -361,9 +361,7 @@ class HomeScreenWidget(QtWidgets.QWidget):
         if path and os.path.exists(path) and path.lower().endswith(".dbc"):
             return path
 
-        file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
-            self, "Select DBC File", "", "DBC Files (*.dbc);;All Files (*)"
-        )
+        file_path = open_file_dialog("Select DBC File", "DBC Files (*.dbc);;All Files (*)")
         if not file_path:
             return None
         if not file_path.lower().endswith(".dbc"):

--- a/src/resource_utils.py
+++ b/src/resource_utils.py
@@ -12,6 +12,7 @@ Centralizing this avoids duplicating the same logic across multiple modules.
 from __future__ import annotations
 
 import os
+import re
 import sys
 
 
@@ -29,5 +30,100 @@ def get_resource_path(relative_path: str) -> str:
     # Dev mode: project root = ../ (since this file lives in ./src)
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     return os.path.join(project_root, relative_path)
+
+
+# ---------------------------------------------------------------------------
+# File dialog helpers
+#
+# On Linux and macOS, Qt's QFileDialog works correctly and is used directly.
+#
+# On Windows, Qt 5.15.2's QFileDialog crashes on Windows 11 due to a
+# regression in the Windows shell's IFileDialog COM integration.  The crash
+# occurs for both native and non-native dialog modes.
+#
+# The fix for Windows is to open the dialog in a separate powershell.exe
+# process using System.Windows.Forms.OpenFileDialog / SaveFileDialog.
+# Because the dialog runs outside the Qt process, the two event loops never
+# share a thread and the crash disappears.  This approach also works in
+# PyInstaller-frozen executables, where spawning `sys.executable -c …`
+# would fail (sys.executable is the bundled .exe, not python.exe).
+# ---------------------------------------------------------------------------
+
+def _qt_filter_to_winforms(qt_filter: str) -> str:
+    """Convert a Qt-style filter string to a WinForms FileDialog Filter string.
+
+    Qt      : "DBC Files (*.dbc);;All Files (*)"
+    WinForms: "DBC Files (*.dbc)|*.dbc|All Files (*.*)|*.*"
+    """
+    parts = []
+    for part in qt_filter.split(";;"):
+        part = part.strip()
+        m = re.match(r"^(.+?)\s*\((.+?)\)$", part)
+        if m:
+            label = m.group(1).strip()
+            exts  = m.group(2).strip()
+            if exts == "*":
+                exts = "*.*"
+            parts.append(f"{label} ({exts})|{exts}")
+    return "|".join(parts) if parts else "*.*|*.*"
+
+
+def _ps_str(s: str) -> str:
+    """Escape a string for use inside a PowerShell single-quoted literal."""
+    return s.replace("'", "''")
+
+
+def _run_powershell_dialog(ps_command: str) -> str:
+    """Run a PowerShell one-liner and return the path printed to stdout."""
+    import subprocess
+    try:
+        proc = subprocess.run(
+            ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", ps_command],
+            capture_output=True, text=True, timeout=300,
+        )
+        path = proc.stdout.strip()
+        return os.path.normpath(path) if path else ""
+    except Exception:
+        return ""
+
+
+def open_file_dialog(title: str, qt_filter: str = "All Files (*)") -> str:
+    """Show an open-file dialog; return the chosen path, or '' if cancelled."""
+    if sys.platform != "win32":
+        from PyQt5 import QtWidgets
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(None, title, "", qt_filter)
+        return path
+
+    ps_filter = _qt_filter_to_winforms(qt_filter)
+    cmd = (
+        "Add-Type -AssemblyName System.Windows.Forms; "
+        "$d = New-Object System.Windows.Forms.OpenFileDialog; "
+        f"$d.Title = '{_ps_str(title)}'; "
+        f"$d.Filter = '{_ps_str(ps_filter)}'; "
+        "if ($d.ShowDialog() -eq 'OK') { $d.FileName }"
+    )
+    return _run_powershell_dialog(cmd)
+
+
+def save_file_dialog(title: str, qt_filter: str = "All Files (*)") -> str:
+    """Show a save-file dialog; return the chosen path, or '' if cancelled."""
+    if sys.platform != "win32":
+        from PyQt5 import QtWidgets
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(None, title, "", qt_filter)
+        return path
+
+    ps_filter = _qt_filter_to_winforms(qt_filter)
+    m = re.search(r"\*(\.\w+)", ps_filter)
+    default_ext = m.group(1) if m else ".dbc"
+    cmd = (
+        "Add-Type -AssemblyName System.Windows.Forms; "
+        "$d = New-Object System.Windows.Forms.SaveFileDialog; "
+        f"$d.Title = '{_ps_str(title)}'; "
+        f"$d.Filter = '{_ps_str(ps_filter)}'; "
+        f"$d.DefaultExt = '{default_ext}'; "
+        "$d.AddExtension = $true; "
+        "if ($d.ShowDialog() -eq 'OK') { $d.FileName }"
+    )
+    return _run_powershell_dialog(cmd)
 
 


### PR DESCRIPTION
## Description

Any action that opens a file dialog (loading a DBC file, saving, the Browse… button) crashes the application on **Windows 11** with an access violation inside Qt's Windows shell integration. The dialog briefly flashes, then the process terminates with no error message.

## Root Cause

`PyQt5-Qt5` only ships Windows wheels at version **5.15.2** (all newer releases are Linux/macOS only). Qt 5.15.2's `QFileDialog` crashes on Windows 11 (Build 22000+) due to a regression in the Windows shell's `IFileDialog` COM layer. Both the native dialog mode and `DontUseNativeDialog` are affected — there is no Qt-side workaround for this version/OS combination.

## Fix

Add platform-aware wrappers `open_file_dialog()` and `save_file_dialog()` in `src/resource_utils.py`:

- **Windows** — opens the dialog inside a fresh `powershell.exe` subprocess using `System.Windows.Forms.OpenFileDialog` / `SaveFileDialog`. Because the dialog runs in a separate process, Qt's event loop and the Windows shell message pump never share a thread. This also works in PyInstaller-frozen executables (unlike forking `sys.executable`, which points to the bundled `.exe` in that context).
- **Linux / macOS** — delegates to `QFileDialog` as before; **behaviour is completely unchanged** on those platforms.

## Files Changed

| File | Change |
|---|---|
| `src/resource_utils.py` | Added `open_file_dialog()`, `save_file_dialog()`, and two private helpers |
| `src/DBCUtility.py` | Updated import + 1 call site (`select_dbc_file`) |
| `src/home_screen.py` | Updated import + 1 call site (`_get_or_prompt_for_dbc`) |
| `src/dbc_editor_ui.py` | Updated import + 2 call sites (`load_dbc_file`, `save_as`) |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Application starts without errors
- [x] DBC files can be loaded via Home screen, View tab Browse button, and Edit tab Load button
- [x] DBC files can be saved via Edit tab Save As
- [x] All buttons and features work as expected on Windows 11
- [x] No regressions on Linux/macOS (code path unchanged, `QFileDialog` is still used there)

**Tested on:** Windows 11 Build 26200, Python 3.13.11, PyQt5 5.15.11 / PyQt5-Qt5 5.15.2